### PR TITLE
Fix DAC (short) settling time bit handling

### DIFF
--- a/lib/lpc43xx/dac.c
+++ b/lib/lpc43xx/dac.c
@@ -46,7 +46,7 @@ void dac_init(bool fast)
 
 void dac_set(uint16_t v)
 {
-    DAC_CR = (v & 0x3FF) << 6 | (dac_fast ? DAC_CR_BIAS : 0);
+    DAC_CR = (v & 0x3FF) << 6 | (dac_fast ? 0 : DAC_CR_BIAS);
 }
 
 


### PR DESCRIPTION
According to the LPC43xx User Manual (rev 2.1) a 0 in DAC_CR_BIAS bit leads to shorter settling times and higher power consumption.
